### PR TITLE
Improve context management and add LLM clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,54 @@
-# agentic-ai
+# Agentic AI
+
+This repository contains a minimal proof-of-concept implementation of a
+"Jarvis"-style multi-agent assistant. The design is inspired by the
+planning document provided in the prompt and focuses on a simple command
+line interface that coordinates different agents.
+
+An experimental FastAPI server exposes the same functionality over HTTP.
+
+## Features
+
+* **MultiContextPlanner** orchestrates tasks and keeps history per task in
+  SQLite.
+* **ModelSelector** chooses between three model classes: `local`, `medium`
+  and `heavy` (heuristic based).
+* **Vector store** persists chunks to Chroma and allows retrieval of top-k
+  relevant snippets.
+* **Agents**
+  * `SystemAgent` runs shell commands.
+  * `FileAgent` performs basic file reads and writes.
+  * `CodeAgent` does a trivial text substitution to simulate refactoring.
+  * `SummarizerAgent` truncates logs to 200 characters.
+
+## Usage
+
+Create a virtual environment with Python 3.10+ and install the project in
+editable mode:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -e .
+```
+
+Run the CLI with a command. Prefixes select agents:
+
+```bash
+python -m jarvis.cli !sh ls
+python -m jarvis.cli !file read README.md
+python -m jarvis.cli !code path/to/file.py replacement
+python -m jarvis.cli !summarize
+```
+
+Anything that does not start with `!sh`, `!file`, `!code` or `!summarize`
+will be sent to an LLM. The `ModelSelector` decides whether to use a local
+Ollama model or AWS Bedrock.
+
+The same features are available over HTTP:
+
+```bash
+uvicorn jarvis.api.main:app --reload
+```
+
+Use `/tasks/create` and `/tasks/{id}` endpoints to drive the assistant.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,25 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "jarvis"
+version = "0.1.0"
+description = "Minimal Jarvis-style multi-agent assistant"
+authors = [{name = "Example"}]
+readme = "README.md"
+license = {text = "MIT"}
+requires-python = ">=3.10"
+dependencies = [
+    "fastapi",
+    "uvicorn",
+    "boto3",
+    "chromadb",
+    "sqlalchemy",
+    "pydantic",
+    "requests",
+]
+
+[project.scripts]
+jarvis = "jarvis.cli:main"
+jarvis-api = "jarvis.api.main:app"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+fastapi
+uvicorn
+boto3
+chromadb
+sqlalchemy
+pydantic
+requests

--- a/src/jarvis/__init__.py
+++ b/src/jarvis/__init__.py
@@ -1,0 +1,5 @@
+"""Minimal Jarvis-style multi-agent system."""
+
+from .orchestrator import MultiContextPlanner
+
+__all__ = ["MultiContextPlanner"]

--- a/src/jarvis/agents/base.py
+++ b/src/jarvis/agents/base.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+
+
+@dataclass
+class TaskRequest:
+    task_id: str
+    content: str
+
+
+@dataclass
+class TaskResponse:
+    content: str
+
+
+class Agent(ABC):
+    """Base interface for all agents."""
+
+    @abstractmethod
+    def handle(self, request: TaskRequest) -> TaskResponse:
+        """Process a task request and return a response."""
+        raise NotImplementedError

--- a/src/jarvis/agents/code.py
+++ b/src/jarvis/agents/code.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from .base import Agent, TaskRequest, TaskResponse
+
+
+class CodeAgent(Agent):
+    """Agent that performs very naive code refactoring."""
+
+    def handle(self, request: TaskRequest) -> TaskResponse:
+        path_str, _, replacement = request.content.partition(" ")
+        path = Path(path_str)
+        if not path.exists():
+            return TaskResponse(content=f"File {path_str} not found")
+        text = path.read_text()
+        updated = text.replace("TODO", replacement)
+        path.write_text(updated)
+        return TaskResponse(content=f"Updated {path_str}")

--- a/src/jarvis/agents/file.py
+++ b/src/jarvis/agents/file.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Optional
+
+from .base import Agent, TaskRequest, TaskResponse
+
+
+class FileAgent(Agent):
+    """Agent for simple file operations."""
+
+    def handle(self, request: TaskRequest) -> TaskResponse:
+        parts = request.content.split(maxsplit=1)
+        if not parts:
+            return TaskResponse(content="No command provided")
+        command = parts[0]
+        argument: Optional[str] = parts[1] if len(parts) > 1 else None
+
+        if command == "read" and argument:
+            path = Path(argument)
+            if not path.exists():
+                return TaskResponse(content=f"File {argument} not found")
+            return TaskResponse(content=path.read_text())
+        if command == "write" and argument:
+            name, _, body = argument.partition(" ")
+            Path(name).write_text(body)
+            return TaskResponse(content=f"Wrote to {name}")
+        return TaskResponse(content="Unknown file command")

--- a/src/jarvis/agents/summarizer.py
+++ b/src/jarvis/agents/summarizer.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from .base import Agent, TaskRequest, TaskResponse
+
+
+class SummarizerAgent(Agent):
+    """Very naive summarizer that truncates text to first 200 characters."""
+
+    def handle(self, request: TaskRequest) -> TaskResponse:
+        summary = request.content[:200]
+        return TaskResponse(content=summary)

--- a/src/jarvis/agents/system.py
+++ b/src/jarvis/agents/system.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import subprocess
+from .base import Agent, TaskRequest, TaskResponse
+
+
+class SystemAgent(Agent):
+    """Agent for executing shell commands in a sandboxed way."""
+
+    def handle(self, request: TaskRequest) -> TaskResponse:
+        try:
+            print("SYSTEM CMD:", request.content)
+            result = subprocess.run(
+                request.content,
+                shell=True,
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            output = result.stdout.strip()
+        except subprocess.CalledProcessError as exc:
+            output = exc.stderr.strip()
+        return TaskResponse(content=output)

--- a/src/jarvis/api/main.py
+++ b/src/jarvis/api/main.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+
+from ..orchestrator import MultiContextPlanner
+from ..model_selector import ModelSelector
+
+app = FastAPI(title="Jarvis API")
+planner = MultiContextPlanner()
+selector = ModelSelector()
+
+class CreateTaskRequest(BaseModel):
+    prompt: str
+
+class CreateTaskResponse(BaseModel):
+    task_id: str
+
+class TaskInput(BaseModel):
+    content: str
+
+class TaskOutput(BaseModel):
+    content: str
+
+class ModelSelectionRequest(BaseModel):
+    prompt: str
+
+class ModelSelectionResponse(BaseModel):
+    model: str
+
+@app.post("/select-model", response_model=ModelSelectionResponse)
+def select_model(req: ModelSelectionRequest):
+    model = selector.select(req.prompt)
+    return ModelSelectionResponse(model=model)
+
+@app.post("/tasks/create", response_model=CreateTaskResponse)
+def create_task(req: CreateTaskRequest):
+    task_id = planner.create_task(req.prompt)
+    return CreateTaskResponse(task_id=task_id)
+
+@app.post("/tasks/{task_id}", response_model=TaskOutput)
+def handle_task(task_id: str, input: TaskInput):
+    try:
+        output = planner.handle(task_id, input.content)
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=str(exc))
+    return TaskOutput(content=output)

--- a/src/jarvis/cli.py
+++ b/src/jarvis/cli.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import argparse
+
+from .orchestrator import MultiContextPlanner
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Jarvis-style assistant CLI")
+    parser.add_argument("command", nargs=argparse.REMAINDER, help="Command to execute")
+    args = parser.parse_args()
+
+    planner = MultiContextPlanner()
+    user_input = " ".join(args.command)
+    task_id = planner.create_task(user_input)
+    output = planner.handle(task_id, user_input)
+    print(output)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/jarvis/context_manager.py
+++ b/src/jarvis/context_manager.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List, Iterable
+
+from .db import Base, Task, Chunk, Summary, get_engine, get_sessionmaker
+from .vector_store import ChromaVectorStore
+
+
+@dataclass
+class Context:
+    task_id: str
+    history: List[str] = field(default_factory=list)
+
+
+class ContextManager:
+    """Stores context for multiple tasks in SQLite and Chroma."""
+
+    def __init__(self, db_url: str = "sqlite:///jarvis.db") -> None:
+        self.engine = get_engine(db_url)
+        Base.metadata.create_all(self.engine)
+        self.SessionLocal = get_sessionmaker(self.engine)
+        self.vector_store = ChromaVectorStore()
+        self.contexts: Dict[str, Context] = {}
+
+    def _ensure_task(self, session, task_id: str) -> None:
+        if not session.get(Task, task_id):
+            session.add(Task(id=task_id))
+            session.commit()
+
+    def get(self, task_id: str) -> Context:
+        if task_id not in self.contexts:
+            self.contexts[task_id] = Context(task_id)
+        return self.contexts[task_id]
+
+    def add_chunk(self, task_id: str, content: str) -> None:
+        session = self.SessionLocal()
+        self._ensure_task(session, task_id)
+        session.add(Chunk(task_id=task_id, content=content))
+        self.vector_store.add(f"{task_id}-{len(content)}", content)
+        session.commit()
+        session.close()
+
+    def get_chunks(self, task_id: str, limit: int = 5) -> Iterable[str]:
+        session = self.SessionLocal()
+        chunks = (
+            session.query(Chunk)
+            .filter(Chunk.task_id == task_id)
+            .order_by(Chunk.id.desc())
+            .limit(limit)
+            .all()
+        )
+        texts = [c.content for c in chunks]
+        session.close()
+        return texts
+
+    def query_chunks(self, text: str, limit: int = 5) -> Iterable[str]:
+        return self.vector_store.query(text, limit)
+
+    def add_summary(self, task_id: str, content: str) -> None:
+        session = self.SessionLocal()
+        self._ensure_task(session, task_id)
+        session.add(Summary(task_id=task_id, content=content))
+        session.commit()
+        session.close()

--- a/src/jarvis/db.py
+++ b/src/jarvis/db.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from datetime import datetime
+from sqlalchemy import Column, DateTime, Integer, String, Text, ForeignKey, create_engine
+from sqlalchemy.orm import declarative_base, sessionmaker, relationship
+
+Base = declarative_base()
+
+class Task(Base):
+    __tablename__ = "tasks"
+    id = Column(String, primary_key=True)
+    created_at = Column(DateTime, default=datetime.utcnow)
+    chunks = relationship("Chunk", back_populates="task")
+    summaries = relationship("Summary", back_populates="task")
+
+class Chunk(Base):
+    __tablename__ = "chunks"
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    task_id = Column(String, ForeignKey("tasks.id"))
+    content = Column(Text)
+    created_at = Column(DateTime, default=datetime.utcnow)
+    task = relationship("Task", back_populates="chunks")
+
+class Summary(Base):
+    __tablename__ = "summaries"
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    task_id = Column(String, ForeignKey("tasks.id"))
+    content = Column(Text)
+    created_at = Column(DateTime, default=datetime.utcnow)
+    task = relationship("Task", back_populates="summaries")
+
+
+def get_engine(url: str = "sqlite:///jarvis.db"):
+    return create_engine(url, future=True)
+
+
+def get_sessionmaker(engine):
+    return sessionmaker(bind=engine, autocommit=False, autoflush=False)

--- a/src/jarvis/model_selector.py
+++ b/src/jarvis/model_selector.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+
+class ModelSelector:
+    """Selects a model based on task complexity."""
+
+    def select(self, text: str) -> str:
+        text_lower = text.lower()
+        if "hello" in text_lower:
+            return "local"
+        if "summarize" in text_lower or len(text) < 100:
+            return "medium"
+        return "heavy"

--- a/src/jarvis/orchestrator.py
+++ b/src/jarvis/orchestrator.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import uuid
+
+from .context_manager import ContextManager
+from .model_selector import ModelSelector
+from .agents.base import TaskRequest, TaskResponse
+from .agents.system import SystemAgent
+from .agents.file import FileAgent
+from .agents.code import CodeAgent
+from .agents.summarizer import SummarizerAgent
+from .utils.chunker import chunk_text
+from .services.llm_client import LLMClient
+
+
+class MultiContextPlanner:
+    """Naive orchestrator managing tasks and agents."""
+
+    def __init__(self) -> None:
+        self.context_manager = ContextManager()
+        self.model_selector = ModelSelector()
+        self.system_agent = SystemAgent()
+        self.file_agent = FileAgent()
+        self.code_agent = CodeAgent()
+        self.summarizer_agent = SummarizerAgent()
+        self.llm_client = LLMClient()
+
+    def create_task(self, user_input: str) -> str:
+        task_id = str(uuid.uuid4())[:8]
+        ctx = self.context_manager.get(task_id)
+        ctx.history.append(user_input)
+        for chunk in chunk_text(user_input):
+            self.context_manager.add_chunk(task_id, chunk)
+        return task_id
+
+    def handle(self, task_id: str, user_input: str) -> str:
+        ctx = self.context_manager.get(task_id)
+        ctx.history.append(user_input)
+        if not user_input.startswith("!"):
+            retrieved = self.context_manager.query_chunks(user_input, limit=3)
+        else:
+            retrieved = []
+        for chunk in chunk_text(user_input):
+            self.context_manager.add_chunk(task_id, chunk)
+        if retrieved:
+            user_input = "\n".join(retrieved) + "\n" + user_input
+        model = self.model_selector.select(user_input)
+        if user_input.startswith("!sh "):
+            req = TaskRequest(task_id, user_input[4:])
+            res = self.system_agent.handle(req)
+        elif user_input.startswith("!file "):
+            req = TaskRequest(task_id, user_input[6:])
+            res = self.file_agent.handle(req)
+        elif user_input.startswith("!code "):
+            req = TaskRequest(task_id, user_input[6:])
+            res = self.code_agent.handle(req)
+        elif user_input.startswith("!summarize"):
+            history = "\n".join(ctx.history)
+            req = TaskRequest(task_id, history)
+            res = self.summarizer_agent.handle(req)
+            self.context_manager.add_summary(task_id, res.content)
+        else:
+            generated = self.llm_client.generate(model, user_input)
+            res = TaskResponse(content=generated)
+            ctx.history.append(res.content)
+            for chunk in chunk_text(res.content):
+                self.context_manager.add_chunk(task_id, chunk)
+            return res.content
+        ctx.history.append(res.content)
+        for chunk in chunk_text(res.content):
+            self.context_manager.add_chunk(task_id, chunk)
+        return res.content

--- a/src/jarvis/services/bedrock.py
+++ b/src/jarvis/services/bedrock.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import boto3
+
+class BedrockClient:
+    def __init__(self, region_name: str = "us-east-1") -> None:
+        self.client = boto3.client("bedrock-runtime", region_name=region_name)
+
+    def generate(self, prompt: str) -> str:
+        # This is a simplified call; real parameters may differ.
+        response = self.client.invoke_model(body=prompt.encode(), modelId="claude-v1")
+        return response.get("body", b"").decode()

--- a/src/jarvis/services/llm_client.py
+++ b/src/jarvis/services/llm_client.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from .ollama import OllamaClient
+from .bedrock import BedrockClient
+
+
+class LLMClient:
+    def __init__(self) -> None:
+        self.ollama = OllamaClient()
+        self.bedrock = BedrockClient()
+
+    def generate(self, model: str, prompt: str) -> str:
+        if model == "local":
+            return self.ollama.generate(prompt)
+        return self.bedrock.generate(prompt)

--- a/src/jarvis/services/ollama.py
+++ b/src/jarvis/services/ollama.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+import requests
+
+class OllamaClient:
+    def __init__(self, host: str = "http://localhost:11434") -> None:
+        self.host = host
+
+    def generate(self, prompt: str) -> str:
+        resp = requests.post(f"{self.host}/api/generate", json={"prompt": prompt})
+        resp.raise_for_status()
+        data = resp.json()
+        return data.get("response", "")

--- a/src/jarvis/utils/chunker.py
+++ b/src/jarvis/utils/chunker.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+def chunk_text(text: str, size: int = 1024) -> list[str]:
+    """Split text into roughly size-byte chunks."""
+    return [text[i : i + size] for i in range(0, len(text), size)]

--- a/src/jarvis/vector_store.py
+++ b/src/jarvis/vector_store.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+import chromadb
+
+class ChromaVectorStore:
+    """Minimal wrapper around Chroma vector store."""
+
+    def __init__(self, path: str = "chroma.db") -> None:
+        self.client = chromadb.PersistentClient(path=path)
+        self.collection = self.client.get_or_create_collection("chunks")
+
+    def add(self, doc_id: str, text: str) -> None:
+        self.collection.add(documents=[text], ids=[doc_id])
+
+    def query(self, text: str, limit: int = 5) -> list[str]:
+        res = self.collection.query(query_texts=[text], n_results=limit)
+        return [doc for doc in res.get("documents", [[]])[0]]


### PR DESCRIPTION
## Summary
- persist task history to SQLite and store embeddings in Chroma
- implement chunking helper and simple vector store wrapper
- add Ollama and Bedrock LLM clients with unified interface
- allow orchestrator to retrieve relevant chunks
- document new capabilities in README

## Testing
- `python -m pip install -e .` (logs show packages installed)
- `python -m jarvis.cli !sh echo hi`
- `python -m jarvis.cli !summarize`
- `uvicorn jarvis.api.main:app --port 8000 &`
- `curl -s -X POST http://localhost:8000/tasks/create -d '{"prompt":"hello"}'`
- `curl -s -X POST http://localhost:8000/tasks/<id> -d '{"content":"!sh echo hi"}'`


------
https://chatgpt.com/codex/tasks/task_e_6847d5156934832984176c0622231fbf